### PR TITLE
Provide docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM openjdk:8-jdk-alpine as builder
+
+WORKDIR /code
+
+ADD . /code
+
+RUN /bin/sh gradlew installDist
+
+FROM openjdk:8-jre-alpine
+
+COPY --from=builder /code/build/install/ /opt/
+
+RUN ln -s /opt/citygml-tools/bin/citygml-tools /usr/local/bin/ && \
+    adduser -D -S -h /data -s /sbin/nologin -G root --uid 1001 citygml-tools && \
+    chgrp 0 /etc/passwd && \
+    chmod g=u /etc/passwd && \
+    chgrp -R 0 /data && \
+    chmod -R g=u /data
+
+COPY --chown=1001:0 docker_uid_entrypoint.sh /usr/local/bin/
+
+WORKDIR /data
+
+USER 1001
+
+ENTRYPOINT ["/usr/local/bin/docker_uid_entrypoint.sh"]
+
+CMD ["--help"]

--- a/docker_uid_entrypoint.sh
+++ b/docker_uid_entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+set -e
+
+# Create passwd entry for arbitrary user ID
+if [[ -z "$(awk -F ':' "\$3 == $(id -u)" /etc/passwd)" ]]; then
+    echo "Adding arbitrary user"
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+    echo "$(awk -F ':' "\$3 == $(id -u)" /etc/passwd)"
+fi
+
+case "$@" in
+    /*)
+        exec "$@";;
+    *)
+        citygml-tools $@;;
+esac
+


### PR DESCRIPTION
### Description

This PR provides a Docker image to run `citygml-tools` inside a container without installing any Java dependencies on the host. Please feel free to use this image and publish it on an image registry of your choice.

### Technical details

It uses Alpine Linux to keep the resulting images small. Additionally, it is written as multi-stage image, which means the "JDK image" is only used for building, while the final application gets wrapped in a smaller "JRE image".

By default, the container process is executed as non-root user. The included entrypoint script allows the image also to be used in OpenShift environments, where an arbitrary user might be created on container start.

The default working directory inside the container is `/data`.

### Usage

1. Build the image, e.g.
    ```shell
    docker build -t citygml-tools .
    ```

2. By default, running the container shows the help message
    ```shell
    docker run --rm citygml-tools
    ```

3. Mount a volume and run any other citycml-tools command, e.g.
    ```shell
    docker run --rm -u 1000 -v /my/cityjson/data:/data citygml-tools from-cityjson /data
    ```

    **Notes:**
    - In this case, `citygml-tools` is the name of the image.
    - Use the `-u` parameter to pass the user ID of your current host's user to set the right permissions on generated files in the mounted directory.